### PR TITLE
Fix butterfly Te Reo Māori translation

### DIFF
--- a/src/constants/animals.ts
+++ b/src/constants/animals.ts
@@ -15,6 +15,6 @@ export const ANIMALS: Animal[] = [
   { id: '7', english: 'Kiwi', maori: 'Kiwi', image: 'kiwi' },
   { id: '8', english: 'Pukeko', maori: 'Pūkeko', image: 'pukeko' },
   { id: '9', english: 'Tui', maori: 'Tūī', image: 'tui' },
-  { id: '10', english: 'Butterfly', maori: 'Pēpepe', image: 'butterfly' },
+  { id: '10', english: 'Butterfly', maori: 'Pūrerehua', image: 'butterfly' },
   { id: '11', english: 'Snail', maori: 'Pupu', image: 'snail' },
 ];


### PR DESCRIPTION
## Summary
- Corrected the Te Reo Māori translation for butterfly from "Pēpepe" to "Pūrerehua"

## Test plan
- [x] Verify the butterfly card displays "Pūrerehua" in the game
- [x] Ensure the memory matching still works correctly with the updated translation